### PR TITLE
Fix path ignore syntax for ECR Build & Push workflow

### DIFF
--- a/workflow-templates/ecr-build-push.yml
+++ b/workflow-templates/ecr-build-push.yml
@@ -11,10 +11,9 @@ on:
       - "package-lock.json"
       - "tsconfig.json"
       - "bun.lockb"
-    paths-ignore:
-      - "README.md"
-      - ".gitignore"
-      - "terraform/**"
+      - "!README.md"
+      - "!.gitignore"
+      - "!terraform/**"
 
 jobs:
   build_and_push:


### PR DESCRIPTION
Seeing this error when using this workflow as is:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/ded95ae2-ba4a-4873-b1f3-139202cd09ae" />
