### PR TITLE
Revert paapy-onboarding to v3

### DIFF
--- a/workflow-templates/paapy-onboarding.yml
+++ b/workflow-templates/paapy-onboarding.yml
@@ -137,7 +137,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: PaaPy Onboarding
-        uses: humalytix/PaaPy-onboarding@v4
+        uses: humalytix/PaaPy-onboarding@v3
         id: onboarding
         with:
           env: nonprod
@@ -171,7 +171,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: PaaPy Onboarding
-        uses: humalytix/PaaPy-onboarding@v4
+        uses: humalytix/PaaPy-onboarding@v3
         id: onboarding
         with:
           env: prod


### PR DESCRIPTION
Onboarding v4 creates the ECS Execution task roles in AWS, which conflicts with PaaPy-ECS. Reverting to v3 for now.