### PR TITLE
Upgrade PaaPy onboarding to v5 and fix op-token references

### DIFF
--- a/workflow-templates/paapy-offboarding.yml
+++ b/workflow-templates/paapy-offboarding.yml
@@ -92,7 +92,7 @@ jobs:
           app-token: ${{ steps.app-token.outputs.token }}
           harness-token: ${{ secrets.HARNESS_IO_SECRET }}
           offboarding: true
-          op-token: ''
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           service-name: ${{ env.service-name }}
           service-type: ${{ env.service-type }}
 

--- a/workflow-templates/paapy-onboarding.yml
+++ b/workflow-templates/paapy-onboarding.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           app-token: ${{ steps.app-token.outputs.token }}
           harness-token: ${{ secrets.HARNESS_IO_SECRET }}
-          op-token: ${{ needs.onepass.outputs.token }}
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           service-name: ${{ env.service-name }}
           service-type: ${{ env.service-type }}
 
@@ -137,7 +137,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: PaaPy Onboarding
-        uses: humalytix/PaaPy-onboarding@v3
+        uses: humalytix/PaaPy-onboarding@v5
         id: onboarding
         with:
           env: nonprod
@@ -171,7 +171,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: PaaPy Onboarding
-        uses: humalytix/PaaPy-onboarding@v3
+        uses: humalytix/PaaPy-onboarding@v5
         id: onboarding
         with:
           env: prod


### PR DESCRIPTION
## Summary
- Upgrade `PaaPy-onboarding` action from v3 to v5 in both nonprod and prod jobs
- Fix `op-token` in `paapy-onboarding.yml` to use `OP_SERVICE_ACCOUNT_TOKEN` secret instead of job output
- Fix `op-token` in `paapy-offboarding.yml` to use `OP_SERVICE_ACCOUNT_TOKEN` secret instead of empty string

Synced from changes applied in `test-harness-cli`.

## Test plan
- [ ] Verify onboarding workflow runs successfully with v5 action
- [ ] Verify offboarding workflow correctly passes op-token

🤖 Generated with [Claude Code](https://claude.com/claude-code)